### PR TITLE
Change networkmanager to modemmanager

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -127,7 +127,7 @@ in
     };
 
     # https://github.com/jhovold/linux/wiki/X13s#modem
-    networking.networkmanager.fccUnlockScripts = [
+    networking.modemmanager.fccUnlockScripts = [
       {
         id = "105b:e0c3";
         path = "${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/105b";


### PR DESCRIPTION
Nixos update module rename causes
```
evaluation warning: The option `networking.networkmanager.fccUnlockScripts' defined in `...' has been renamed to `networking.modemmanager.fccUnlockScripts'.
```